### PR TITLE
Add example for setNumEntries

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -46,6 +46,9 @@ Ruby wrapper for Google AJAX API REST interfaces(Feeds, Language and Search).
   # Load 4 most recent entries from 'http://monki.geemus.com/feed/atom.xml'
   GoogleAjax::Feed.load('http://monki.geemus.com/feed/atom.xml')
 
+  # Load 10 entries instead of the default 4
+  GoogleAjax::Feed.load(url, {num: 10})
+
   # Find feed for 'http://monki.geemus.com'
   GoogleAjax::Feed.lookup('http://monki.geemus.com')
 

--- a/lib/googleajax/feed.rb
+++ b/lib/googleajax/feed.rb
@@ -17,7 +17,7 @@ module GoogleAjax
     ##
     # :call-seq:
     #   lookup(url, args = {})
-    # will return the associated feed if it exists for a given url    
+    # will return the associated feed if it exists for a given url
     # Arguments: http://code.google.com/apis/ajaxfeeds/documentation/reference.html#_intro_fonje
     standard_api :lookup
   end


### PR DESCRIPTION
Turns out you can already pass in arguments to the load function. So I simply added the example to the readme.

```
    # :call-seq:
    #   load(url, args = {})
    # downloads this feed from Google's servers
    # Arguments: http://code.google.com/apis/ajaxfeeds/documentation/reference.html#_fonje_load
    standard_api(:load){|h| h['feed']}
```
